### PR TITLE
Work/signals fixes

### DIFF
--- a/ApplicationCode/include/control.h
+++ b/ApplicationCode/include/control.h
@@ -38,7 +38,7 @@ public:
           _selected_controller(nullptr),
           _selected_input_signal(&_heaviside),
           _regression(),
-          _system(_selected_object, _selected_controller, Control_System::Control_Mode::OPEN_LOOP),
+          _system(_selected_object, Control_System::Control_Mode::OPEN_LOOP),
           _tuner(_system, _regression),
           _operation_type(Operation_Type::SIMULATION)
     {
@@ -67,9 +67,12 @@ public:
         }
         // If it will be handled like that then input to function will have to take matrices into account and base class
         // as well will have to overload.
-        _selected_object->set_order(static_cast<std::size_t>(order));
-        _selected_object->set_parameters(object_parameters);
-        _selected_object->set_time_step(time_step);
+        if(_selected_object != nullptr)
+        {
+            _selected_object->set_order(static_cast<std::size_t>(order));
+            _selected_object->set_parameters(object_parameters);
+            _selected_object->set_time_step(time_step);
+        }
     }
 
     void
@@ -85,12 +88,12 @@ public:
         {
             case Controller_Type::BANG_BANG:
             {
-                _selected_controller = &_bang_bang_controller;
+                _selected_controller = std::make_shared<Bang_Bang_Controller>(_bang_bang_controller);
                 break;
             }
             case Controller_Type::PID:
             {
-                _selected_controller = &_pid_controller;
+                _selected_controller = std::make_shared<PID>(_pid_controller);
                 break;
             }
             case Controller_Type::NONE:
@@ -101,8 +104,13 @@ public:
             default:
                 break;
         }
-        _selected_controller->set_time_step(time_step);
-        _selected_controller->set_parameters(controller_parameters);
+
+        if(_selected_controller != nullptr)
+        {
+            _selected_controller->set_time_step(time_step);
+            _selected_controller->set_parameters(controller_parameters);
+            _system.set_controller(_selected_controller);
+        }
     }
 
     void
@@ -151,8 +159,12 @@ public:
             default:
                 break;
         }
-        _selected_input_signal->set_time_step(time_step);
-        _selected_input_signal->set_parameters(signal_basic_parameters);
+
+        if(_selected_input_signal != nullptr)
+        {
+            _selected_input_signal->set_time_step(time_step);
+            _selected_input_signal->set_parameters(signal_basic_parameters);
+        }
     }
 
     void
@@ -164,13 +176,21 @@ public:
     double
     get_time() const
     {
-        return _selected_input_signal->time();
+        if(_selected_input_signal != nullptr)
+        {
+            return _selected_input_signal->time();
+        }
+        return 0.0;
     }
 
     double
     get_setpoint() const
     {
-        return _selected_input_signal->get_value();
+        if(_selected_input_signal != nullptr)
+        {
+            return _selected_input_signal->get_value();
+        }
+        return 0.0;
     }
 
     double
@@ -188,6 +208,11 @@ public:
     void
     update()
     {
+        if(_selected_input_signal == nullptr)
+        {
+            assert(false);
+            return;
+        }
         _system.update(_selected_input_signal->get_value());
         _selected_input_signal->update();
     }
@@ -201,14 +226,20 @@ public:
     void
     reset()
     {
-        _selected_object->reset();
+        if(_selected_object != nullptr)
+        {
+            _selected_object->reset();
+        }
 
         if(_selected_controller != nullptr)
         {
             _selected_controller->reset();
         }
 
-        _selected_input_signal->reset();
+        if(_selected_input_signal != nullptr)
+        {
+            _selected_input_signal->reset();
+        }
     }
 
 private:
@@ -223,7 +254,7 @@ private:
     Pulse_Wave _pulse_wave;
 
     Object_Representation_Base* _selected_object;
-    Controller_Base* _selected_controller;
+    std::shared_ptr<Controller_Base> _selected_controller;  // nullptr as default controller, this requires shared_ptr
     Signal_Base* _selected_input_signal;
 
     Recursive_Linear_Regression _regression;

--- a/ApplicationCode/include/input_parameters_container.h
+++ b/ApplicationCode/include/input_parameters_container.h
@@ -91,7 +91,7 @@ public:
     void
     set_period(double period)
     {
-        _line_edit_inputs.on_time = period;
+        _line_edit_inputs.period = period;
     }
 
     void

--- a/ApplicationCode/include/input_parameters_container.h
+++ b/ApplicationCode/include/input_parameters_container.h
@@ -15,11 +15,11 @@ class Input_Parameters_Container
         std::vector<double> controller_parameters {1.0, 1.0, 0.0};
         double start_time {0.0};
         double scaler {1.0};
-        double on_time {0.0};
-        double omega {0.0};
+        double on_time {5.0};
+        double omega {1.0};
         double offset {0.0};
-        double duty_cycle {0.0};
-        double period {0.0};
+        double duty_cycle {0.5};
+        double period {2.0};
         double simulation_time {10.0};
     };
 

--- a/ApplicationCode/include/input_parameters_container.h
+++ b/ApplicationCode/include/input_parameters_container.h
@@ -20,7 +20,7 @@ class Input_Parameters_Container
         double offset {0.0};
         double duty_cycle {0.0};
         double period {0.0};
-        double simulation_time {1.0};
+        double simulation_time {10.0};
     };
 
     struct ComboBoxes_Inputs

--- a/ApplicationCode/include/inputs_parser.h
+++ b/ApplicationCode/include/inputs_parser.h
@@ -20,19 +20,13 @@ public:
     void
     parse_line_edit_id(QLineEdit* line_edit, LineEdit_ID line_edit_id)
     {
-        bool ok;
         switch(line_edit_id)
         {
             case LineEdit_ID::OBJECT_PARAMETERS_LINE_EDIT:
             {
                 int const object_parameters_limit = _inputs.get_order() + 1;
                 std::vector<double> const object_parameters =
-                    parse_vector_parameters(line_edit, object_parameters_limit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                    parse_vector_parameters(line_edit, object_parameters_limit);
                 _inputs.set_object_parameters(object_parameters);
                 break;
             }
@@ -40,100 +34,56 @@ public:
             {
                 int const controller_parameters_limit = 3;  // PID and Bang-Bang Controllers.
                 std::vector<double> const controller_parameters =
-                    parse_vector_parameters(line_edit, controller_parameters_limit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                    parse_vector_parameters(line_edit, controller_parameters_limit);
                 _inputs.set_controller_parameters(controller_parameters);
                 break;
             }
             case LineEdit_ID::START_TIME_LINE_EDIT:
             {
-                double const start_time = parse_single_number_line_edit(line_edit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const start_time = parse_single_number_line_edit(line_edit);
                 _inputs.set_start_time(start_time);
                 break;
             }
             case LineEdit_ID::SCALER_LINE_EDIT:
             {
-                double const scaler = parse_single_number_line_edit(line_edit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const scaler = parse_single_number_line_edit(line_edit);
                 _inputs.set_scaler(scaler);
                 break;
             }
             case LineEdit_ID::ON_TIME_LINE_EDIT:
             {
-                double const on_time = parse_single_number_line_edit(line_edit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const on_time = parse_single_number_line_edit(line_edit);
                 _inputs.set_on_time(on_time);
                 break;
             }
             case LineEdit_ID::OMEGA_LINE_EDIT:
             {
-                double const omega = parse_single_number_line_edit(line_edit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const omega = parse_single_number_line_edit(line_edit);
                 _inputs.set_omega(omega);
                 break;
             }
             case LineEdit_ID::OFFSET_LINE_EDIT:
             {
-                double const offset = parse_single_number_line_edit(line_edit, ok, std::numeric_limits<double>::min());
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const offset = parse_single_number_line_edit(line_edit, std::numeric_limits<double>::min());
                 _inputs.set_offset(offset);
                 break;
             }
             case LineEdit_ID::PERIOD_LINE_EDIT:
             {
-                double const period = parse_single_number_line_edit(line_edit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const period = parse_single_number_line_edit(line_edit);
                 _inputs.set_period(period);
                 break;
             }
             case LineEdit_ID::DUTY_CYCLE_LINE_EDIT:
             {
-                double const duty_cycle_percent = parse_single_number_line_edit(line_edit, ok, 0.0, 100.0);
-                if(!ok)
-                {
-                    return;
-                }
-                static double const percent_to_fraction = 1e-02;
+                double const duty_cycle_percent         = parse_single_number_line_edit(line_edit, 0.0, 100.0);
+                static double const percent_to_fraction = 0.01;
                 _inputs.set_duty_cycle(duty_cycle_percent * percent_to_fraction);
                 break;
             }
             case LineEdit_ID::SIMULATION_TIME_LINE_EDIT:
             {
-                double const simulation_time = parse_single_number_line_edit(line_edit, ok);
-                if(!ok)
-                {
-                    return;
-                }
-
+                double const simulation_time = parse_single_number_line_edit(line_edit);
                 _inputs.set_simulation_time(simulation_time);
                 break;
             }
@@ -205,13 +155,14 @@ public:
 
     // This will need some error protections.
     std::vector<double>
-    parse_vector_parameters(QLineEdit* line_edit, int parameters_limit, bool& ok)
+    parse_vector_parameters(QLineEdit* line_edit, int parameters_limit)
     {
         QStringList const parameters_string_list    = line_edit->text().split("|", Qt::SkipEmptyParts);
         std::size_t const entered_parameters_number = parameters_string_list.size();
         std::vector<double> parameters {};
         parameters.reserve(parameters_limit);
 
+        bool ok;
         std::size_t idx = 1;
         for(auto const& parameter: parameters_string_list)
         {
@@ -264,9 +215,9 @@ public:
 
     double
     parse_single_number_line_edit(
-        QLineEdit* line_edit, bool& ok, double lower_limit = 0.0,
-        double upper_limit = std::numeric_limits<double>::max())
+        QLineEdit* line_edit, double lower_limit = 0.0, double upper_limit = std::numeric_limits<double>::max())
     {
+        bool ok;
         double const value = line_edit->text().toDouble(&ok);
         if(!ok)
         {
@@ -278,17 +229,15 @@ public:
         if(value != 0.0 && value < lower_limit)
         {
             Q_EMIT value_below_lower_limit(lower_limit);
-            ok = false;
             line_edit->setText(QString::number(lower_limit));
-            return 0.0;
+            return lower_limit;
         }
 
         if(value > upper_limit)
         {
             Q_EMIT value_above_upper_limit(upper_limit);
-            ok = false;
             line_edit->setText(QString::number(upper_limit));
-            return 0.0;
+            return upper_limit;
         }
         return value;
     }

--- a/ApplicationCode/include/inputs_parser.h
+++ b/ApplicationCode/include/inputs_parser.h
@@ -117,13 +117,13 @@ public:
             }
             case LineEdit_ID::DUTY_CYCLE_LINE_EDIT:
             {
-                double const duty_cycle = parse_single_number_line_edit(line_edit, ok, 0.0, 1.0);
+                double const duty_cycle_percent = parse_single_number_line_edit(line_edit, ok, 0.0, 100.0);
                 if(!ok)
                 {
                     return;
                 }
-
-                _inputs.set_duty_cycle(duty_cycle);
+                static double const percent_to_fraction = 1e-02;
+                _inputs.set_duty_cycle(duty_cycle_percent * percent_to_fraction);
                 break;
             }
             case LineEdit_ID::SIMULATION_TIME_LINE_EDIT:
@@ -275,7 +275,7 @@ public:
             return 0.0;
         }
 
-        if(value < lower_limit)
+        if(value != 0.0 && value < lower_limit)
         {
             Q_EMIT value_below_lower_limit(lower_limit);
             ok = false;

--- a/ApplicationCode/include/main_widget.h
+++ b/ApplicationCode/include/main_widget.h
@@ -222,11 +222,11 @@ private:
         set_up_line_edit(scaler_line_edit, "1.0", "<p><i>Set up scaler parameter.</i></p>");
 
         ClickableLineEdit* on_time_line_edit = new ClickableLineEdit();
-        set_up_line_edit(on_time_line_edit, "0.0", "<p><i>Set up on time in seconds.</i></p>");
+        set_up_line_edit(on_time_line_edit, "5.0", "<p><i>Set up on time in seconds.</i></p>");
         on_time_line_edit->hide();
 
         ClickableLineEdit* omega_line_edit = new ClickableLineEdit();
-        set_up_line_edit(omega_line_edit, "0.0", "<p><i>Set up omega in radians per second.</i></p>");
+        set_up_line_edit(omega_line_edit, "1.0", "<p><i>Set up omega in radians per second.</i></p>");
         omega_line_edit->hide();
 
         ClickableLineEdit* offset_line_edit = new ClickableLineEdit();
@@ -234,11 +234,11 @@ private:
         offset_line_edit->hide();
 
         ClickableLineEdit* period_line_edit = new ClickableLineEdit();
-        set_up_line_edit(period_line_edit, "0.0", "<p><i>Set up period in seconds.</i></p>");
+        set_up_line_edit(period_line_edit, "2.0", "<p><i>Set up period in seconds.</i></p>");
         period_line_edit->hide();
 
         ClickableLineEdit* duty_cycle_line_edit = new ClickableLineEdit();
-        set_up_line_edit(duty_cycle_line_edit, "0.0", "<p><i>Set up duty cycle 0 - 100%.</i></p>");
+        set_up_line_edit(duty_cycle_line_edit, "50.0", "<p><i>Set up duty cycle 0 - 100%.</i></p>");
         duty_cycle_line_edit->hide();
 
         QGridLayout* grid_Layout = new QGridLayout();

--- a/ApplicationCode/include/main_widget.h
+++ b/ApplicationCode/include/main_widget.h
@@ -172,7 +172,7 @@ private:
         set_up_combobox(operation_combobox, {"Simulation", "Tuning"});
 
         ClickableLineEdit* simulation_time_line_edit = new ClickableLineEdit();
-        set_up_line_edit(simulation_time_line_edit, "1.0", "<p><i>Enter operation time in seconds.</i></p>", true);
+        set_up_line_edit(simulation_time_line_edit, "10.0", "<p><i>Enter operation time in seconds.</i></p>", true);
 
         QComboBox* _simulation_step_combobox = new QComboBox();
         set_up_combobox(_simulation_step_combobox, {"0.01", "0.001", "0.0001"}, true);
@@ -210,7 +210,7 @@ private:
         QLabel* period_label = new QLabel("Period [s]: ");
         period_label->hide();
 
-        QLabel* duty_cycle_label = new QLabel("Duty cycle: ");
+        QLabel* duty_cycle_label = new QLabel("Duty cycle [%]: ");
         duty_cycle_label->hide();
 
         line_edit_id = static_cast<int>(LineEdit_ID::START_TIME_LINE_EDIT);
@@ -238,7 +238,7 @@ private:
         period_line_edit->hide();
 
         ClickableLineEdit* duty_cycle_line_edit = new ClickableLineEdit();
-        set_up_line_edit(duty_cycle_line_edit, "0.0", "<p><i>Set up duty cycle [0 - 1].</i></p>");
+        set_up_line_edit(duty_cycle_line_edit, "0.0", "<p><i>Set up duty cycle 0 - 100%.</i></p>");
         duty_cycle_line_edit->hide();
 
         QGridLayout* grid_Layout = new QGridLayout();

--- a/LogicCode/include/base_classes/simulation_object_base.h
+++ b/LogicCode/include/base_classes/simulation_object_base.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include <assert.h>
-#include <iostream>
 
 class Simulation_Object_Base
 {

--- a/LogicCode/include/control_system.h
+++ b/LogicCode/include/control_system.h
@@ -2,6 +2,7 @@
 // Description : Control loop system.
 
 #pragma once
+#include <memory>
 #include "base_classes/controller_base.h"
 #include "base_classes/object_representation_base.h"
 
@@ -12,11 +13,19 @@ public:
     enum class Control_Mode : std::uint8_t
     {
         OPEN_LOOP,
-        CLOSED_LOOP
+        CLOSED_LOOP,
+        NONE
     };
 
-    Control_System(Object_Representation_Base* object, Controller_Base*& controller, Control_Mode const& control_mode)
-        : _object(object), _controller(controller), _control_mode(control_mode)
+    Control_System(
+        Object_Representation_Base* object, std::shared_ptr<Controller_Base> controller,
+        Control_Mode const& control_mode)
+        : _object(object), _controller(std::move(controller)), _control_mode(control_mode)
+    {
+    }
+
+    Control_System(Object_Representation_Base* object, Control_Mode const& control_mode)
+        : Control_System(object, nullptr, control_mode)
     {
     }
 
@@ -35,7 +44,11 @@ public:
         }
         else
         {
-            double const error = set_point - _object->get_value();
+            double error = set_point;
+            if(_object != nullptr)
+            {
+                error -= _object->get_value();
+            }
 
             if(_controller != nullptr)
             {
@@ -48,7 +61,10 @@ public:
             }
         }
 
-        _object->update(object_update_value);
+        if(_object != nullptr)
+        {
+            _object->update(object_update_value);
+        }
     }
 
     double
@@ -91,13 +107,13 @@ public:
         return {};
     }
 
-    Controller_Base const*
+    std::shared_ptr<Controller_Base> const
     get_controller() const
     {
         return _controller;
     }
 
-    Controller_Base*
+    std::shared_ptr<Controller_Base>
     get_controller()
     {
         return _controller;
@@ -126,8 +142,14 @@ public:
         _control_mode = control_mode;
     }
 
+    void
+    set_controller(std::shared_ptr<Controller_Base> controller)
+    {
+        _controller = std::move(controller);
+    }
+
 private:
     Control_Mode _control_mode {};
     Object_Representation_Base* _object {nullptr};
-    Controller_Base*& _controller;
+    std::shared_ptr<Controller_Base> _controller {nullptr};
 };

--- a/LogicCode/include/signals.h
+++ b/LogicCode/include/signals.h
@@ -182,6 +182,7 @@ public:
     void
     reset() override
     {
+        Rectangle::reset();
         set_value(0.0);
         reset_timer();
         _periods_counter = 1u;

--- a/Tests/test_suites/control_system_with_bang_bang_controller_test.cpp
+++ b/Tests/test_suites/control_system_with_bang_bang_controller_test.cpp
@@ -2,6 +2,7 @@
 // Description : Unit tests for control system - open/closed loop.
 
 #include <gtest/gtest.h>
+#include <memory>
 #include "bang_bang_controller.h"
 #include "object_differential_equation_representation.h"
 #include "signals.h"
@@ -19,19 +20,20 @@ protected:
     void
     test_open_loop_control()
     {
-        Test_With_Plot::test_open_loop_control(&_object, &_two_position_controller, &_pulse, true);
+        Test_With_Plot::test_open_loop_control(&_object, _bang_bang_controller, &_pulse, true);
     }
 
     void
     test_closed_loop_control()
     {
-        Test_With_Plot::test_closed_loop_control(&_object, &_two_position_controller, &_pulse, true);
+        Test_With_Plot::test_closed_loop_control(&_object, _bang_bang_controller, &_pulse, true);
     }
 
 private:
     double const _time_step = 0.01;
     Pulse_Wave _pulse {_time_step, 0.75, 4.0, {}};
-    Bang_Bang_Controller _two_position_controller {_time_step, {0.0, 1.0, 1.0}};
+    std::shared_ptr<Bang_Bang_Controller> _bang_bang_controller =
+        std::make_shared<Bang_Bang_Controller>(_time_step, std::vector<double> {0.0, 1.0, 1.0});
     ObjectT _object {_time_step, order, {0.0, 0.0}, {1.0, 1.0, 1.0}};
 };
 

--- a/Tests/test_suites/control_system_with_pid_test.cpp
+++ b/Tests/test_suites/control_system_with_pid_test.cpp
@@ -2,6 +2,7 @@
 // Description : Unit tests for control system - open/closed loop.
 
 #include <gtest/gtest.h>
+#include <memory>
 #include "object_differential_equation_representation.h"
 #include "pid.h"
 #include "signals.h"
@@ -18,19 +19,19 @@ protected:
     void
     test_open_loop_control()
     {
-        Test_With_Plot::test_open_loop_control(&_object, &_pid, &_sine_wave);
+        Test_With_Plot::test_open_loop_control(&_object, _pid, &_sine_wave);
     }
 
     void
     test_closed_loop_control()
     {
-        Test_With_Plot::test_closed_loop_control(&_object, &_pid, &_sine_wave);
+        Test_With_Plot::test_closed_loop_control(&_object, _pid, &_sine_wave);
     }
 
 private:
     double const _time_step = 0.01;
     Sine_Wave _sine_wave {_time_step, 20.0, 5.0, {}};
-    PID _pid {_time_step, {1.0, 1.0, 1.0}};
+    std::shared_ptr<PID> _pid = std::make_shared<PID>(_time_step, std::vector<double> {1.0, 1.0, 1.0});
     ObjectT _object {_time_step, order, {0.0, 0.0}, {1.0, 1.0, 1.0}};
 };
 

--- a/Tests/test_suites/pid_tuning_test.cpp
+++ b/Tests/test_suites/pid_tuning_test.cpp
@@ -13,10 +13,10 @@
 
 class PidTuningTest : public testing::Test, public Test_With_Plot
 {
-    static constexpr std::uint8_t _order = 2u;
-    static constexpr double _time_step   = 0.01;
-    using ObjectEquationT                = Object_Differential_Equation_Representation;
-    using ObjectStateSpaceT              = Object_State_Space_Representation;
+    static constexpr std::uint8_t order = 2u;
+    static constexpr double time_step   = 0.01;
+    using ObjectEquationT               = Object_Differential_Equation_Representation;
+    using ObjectStateSpaceT             = Object_State_Space_Representation;
 
 protected:
     PidTuningTest() : Test_With_Plot(30.0) {}
@@ -34,19 +34,19 @@ protected:
     }
 
 private:
-    Sine_Wave _sine_wave_1 {_time_step, 1.0, 1.0, {}};
-    PID _pid_1 {_time_step, {}};
-    ObjectEquationT _object_differential_equation_representation {_time_step, _order, {0.0, 0.0}, {2.0, 0.50, 3.0}};
-    Control_System _system_1 {
-        &_object_differential_equation_representation, &_pid_1, Control_System::Control_Mode::CLOSED_LOOP};
-    Pid_Tuner _tuner_1 {_system_1, {}};
+    Sine_Wave _sine_wave_1 {time_step, 1.0, 1.0, {}};
+    std::shared_ptr<PID> pid_1 = std::make_shared<PID>(time_step, std::vector<double> {0.0, 0.0, 0.0});
+    ObjectEquationT object_differential_equation_representation {time_step, order, {0.0, 0.0}, {2.0, 0.50, 3.0}};
+    Control_System system_1 {
+        &object_differential_equation_representation, pid_1, Control_System::Control_Mode::CLOSED_LOOP};
+    Pid_Tuner _tuner_1 {system_1, {}};
 
-    Sine_Wave _sine_wave_2 {_time_step, 1.0, 1.0, {}};
-    PID _pid_2 {_time_step, {}};
-    ObjectStateSpaceT _object_state_space_representation {
-        _time_step, _order, {0.0, 0.0}, {{{0.0, 1.0}, {-0.5, -2.0}}}, {0.0, 3.0}, {1.0, 0.0}};
-    Control_System _system_2 {&_object_state_space_representation, &_pid_2, Control_System::Control_Mode::CLOSED_LOOP};
-    Pid_Tuner _tuner_2 {_system_2, {}};
+    Sine_Wave _sine_wave_2 {time_step, 1.0, 1.0, {}};
+    std::shared_ptr<PID> pid_2 = std::make_shared<PID>(time_step, std::vector<double> {0.0, 0.0, 0.0});
+    ObjectStateSpaceT object_state_space_representation {
+        time_step, order, {0.0, 0.0}, {{{0.0, 1.0}, {-0.5, -2.0}}}, {0.0, 3.0}, {1.0, 0.0}};
+    Control_System system_2 {&object_state_space_representation, pid_2, Control_System::Control_Mode::CLOSED_LOOP};
+    Pid_Tuner _tuner_2 {system_2, {}};
 };
 
 TEST_F(PidTuningTest, TunerWithObjectRepresentedByDifferentialEquationTest)

--- a/Tests/test_suites/resetting_test.cpp
+++ b/Tests/test_suites/resetting_test.cpp
@@ -2,6 +2,7 @@
 // Description : Unit tests for reset operation.
 
 #include <gtest/gtest.h>
+#include <memory>
 #include "control_system.h"
 #include "object_differential_equation_representation.h"
 #include "pid.h"
@@ -22,10 +23,10 @@ protected:
     void
     test_closed_loop_with_resets()
     {
-        Test_With_Plot::test_closed_loop_control(&_object_differential_equation_representation, &_pid, &_step);
+        Test_With_Plot::test_closed_loop_control(&_object_differential_equation_representation, _pid, &_step);
         _object_differential_equation_representation.reset();
-        _pid.reset();
-        Test_With_Plot::test_closed_loop_control(&_object_differential_equation_representation, &_pid, &_step);
+        _pid->reset();
+        Test_With_Plot::test_closed_loop_control(&_object_differential_equation_representation, _pid, &_step);
     }
 
     void
@@ -39,10 +40,10 @@ protected:
 
 private:
     Heaviside _step {_time_step, {5.0, 1.0}};
-    PID _pid {_time_step, {1.0, 1.0, 1.0}};
+    std::shared_ptr<PID> _pid = std::make_shared<PID>(_time_step, std::vector<double> {1.0, 1.0, 1.0});
     ObjectEquationT _object_differential_equation_representation {_time_step, _order, {0.0, -1.0}, {2.0, 0.50, 3.0}};
     Control_System _system {
-        &_object_differential_equation_representation, &_pid, Control_System::Control_Mode::CLOSED_LOOP};
+        &_object_differential_equation_representation, _pid, Control_System::Control_Mode::CLOSED_LOOP};
     Recursive_Linear_Regression _regression {};
     Pid_Tuner _tuner {_system, _regression};
 };

--- a/Tests/test_with_plot.h
+++ b/Tests/test_with_plot.h
@@ -3,7 +3,9 @@
 
 #pragma once
 #include <math.h>
+#include <memory>
 #include <string>
+#include <vector>
 #include "base_classes/controller_base.h"
 #include "base_classes/object_representation_base.h"
 #include "base_classes/signal_base.h"
@@ -38,7 +40,7 @@ public:
 
     void
     test_closed_loop_control(
-        Object_Representation_Base* object, Controller_Base* controller, Signal_Base* input_signal,
+        Object_Representation_Base* object, std::shared_ptr<Controller_Base> controller, Signal_Base* input_signal,
         bool const plot_control = false) const
     {
         Plotting_Buffers const buffers =
@@ -49,7 +51,7 @@ public:
 
     void
     test_open_loop_control(
-        Object_Representation_Base* object, Controller_Base* controller, Signal_Base* input_signal,
+        Object_Representation_Base* object, std::shared_ptr<Controller_Base> controller, Signal_Base* input_signal,
         bool plot_control = false) const
     {
         Plotting_Buffers const buffers =
@@ -70,6 +72,7 @@ public:
     void
     test_tuner(Signal_Base* input_signal, TunerT tuner, bool plot_control = false) const
     {
+        std::cout << "2" << std::endl;
         Plotting_Buffers const buffers = simulate_tuner<TunerT>(input_signal, tuner);
 
         plot_test(buffers, Control_System::Control_Mode::CLOSED_LOOP, plot_control);
@@ -103,7 +106,7 @@ private:
 
     Plotting_Buffers const
     simulate_open_closed_loop(
-        Object_Representation_Base* object, Controller_Base* controller, Signal_Base* input_signal,
+        Object_Representation_Base* object, std::shared_ptr<Controller_Base> controller, Signal_Base* input_signal,
         Control_System::Control_Mode const& control_mode) const
     {
         input_signal->reset();
@@ -152,9 +155,10 @@ private:
         std::vector<double> set_point {};
         std::vector<double> control {};
         std::vector<double> output {};
-
+        std::cout << "1" << std::endl;
         while(input_signal->time() < _sim_time)
         {
+            std::cout << input_signal->time() << std::endl;
             time.push_back(input_signal->time());
             set_point.push_back(input_signal->get_value());
             control.push_back(tuner.get_control());

--- a/Tests/test_with_plot.h
+++ b/Tests/test_with_plot.h
@@ -72,7 +72,6 @@ public:
     void
     test_tuner(Signal_Base* input_signal, TunerT tuner, bool plot_control = false) const
     {
-        std::cout << "2" << std::endl;
         Plotting_Buffers const buffers = simulate_tuner<TunerT>(input_signal, tuner);
 
         plot_test(buffers, Control_System::Control_Mode::CLOSED_LOOP, plot_control);
@@ -155,10 +154,9 @@ private:
         std::vector<double> set_point {};
         std::vector<double> control {};
         std::vector<double> output {};
-        std::cout << "1" << std::endl;
+
         while(input_signal->time() < _sim_time)
         {
-            std::cout << input_signal->time() << std::endl;
             time.push_back(input_signal->time());
             set_point.push_back(input_signal->get_value());
             control.push_back(tuner.get_control());


### PR DESCRIPTION
- `shread_ptr` instead of `*&` syntax for base controller class passing,
- additional `nullptr` protection,
- tests update to match current implementation,
- duty cycle now specified in percents instead of fractions,
- controlled input values of parameters now immediately set to the container,
- introduced viable default values for signals,
- fixed pulse wave reset functionality,