### PR TITLE
Experimental PID Tuning using RLS introduced

### DIFF
--- a/ApplicationCode/include/control.h
+++ b/ApplicationCode/include/control.h
@@ -27,8 +27,8 @@ public:
     Control()
         : _differential_equation_representation_object(TIME_STEP, ORDER),
           _state_space_representation_object(TIME_STEP, ORDER),
-          _pid_controller(TIME_STEP),
-          _bang_bang_controller(TIME_STEP),
+          _pid_controller(std::make_shared<PID>(TIME_STEP)),
+          _bang_bang_controller(std::make_shared<Bang_Bang_Controller>(TIME_STEP)),
           _heaviside(TIME_STEP),
           _ramp(TIME_STEP),
           _rect(TIME_STEP),
@@ -100,12 +100,12 @@ public:
         {
             case Controller_Type::BANG_BANG:
             {
-                _selected_controller = std::make_shared<Bang_Bang_Controller>(_bang_bang_controller);
+                _selected_controller = _bang_bang_controller;
                 break;
             }
             case Controller_Type::PID:
             {
-                _selected_controller = std::make_shared<PID>(_pid_controller);
+                _selected_controller = _pid_controller;
                 break;
             }
             case Controller_Type::NONE:
@@ -206,13 +206,19 @@ public:
     void
     enable_pid_derivative_filtering(bool enable)
     {
-        _pid_controller.enable_derivative_filtering(enable);
+        if(_pid_controller != nullptr)
+        {
+            _pid_controller->enable_derivative_filtering(enable);
+        }
     }
 
     void
     set_pid_derivative_filtering_coefficient(double filtering_coefficient)
     {
-        _pid_controller.set_derivative_filtering_coefficient(filtering_coefficient);
+        if(_pid_controller != nullptr)
+        {
+            _pid_controller->set_derivative_filtering_coefficient(filtering_coefficient);
+        }
     }
 
     double
@@ -255,7 +261,21 @@ public:
             assert(false);
             return;
         }
-        _system.update(_selected_input_signal->get_value());
+
+        double const input = _selected_input_signal->get_value();
+        switch(_operation_type)
+        {
+            case Operation_Type::TUNING:
+                _tuner.update(input);
+                break;
+            case Operation_Type::SIMULATION:
+                _system.update(input);
+                break;
+            default:
+                assert(false);
+                break;
+        }
+
         _selected_input_signal->update();
     }
 
@@ -265,17 +285,46 @@ public:
         return _system.get_control_mode();
     }
 
+    Operation_Type
+    get_operation_type() const
+    {
+        return _operation_type;
+    }
+
+    std::array<double, 3>
+    get_pid_parameters() const
+    {
+        if(_pid_controller != nullptr)
+        {
+            return _pid_controller->get_parameters();
+        }
+
+        assert(false);
+        return {};
+    }
+
     void
     reset()
     {
-        if(_selected_object != nullptr)
+        switch(_operation_type)
         {
-            _selected_object->reset();
-        }
-
-        if(_selected_controller != nullptr)
-        {
-            _selected_controller->reset();
+            case Operation_Type::TUNING:
+                _tuner.reset();
+                _tuner.set_initial_pid_parameters(_pid_controller->get_parameters());
+                break;
+            case Operation_Type::SIMULATION:
+                if(_selected_object != nullptr)
+                {
+                    _selected_object->reset();
+                }
+                if(_selected_controller != nullptr)
+                {
+                    _selected_controller->reset();
+                }
+                break;
+            default:
+                assert(false);
+                break;
         }
 
         if(_selected_input_signal != nullptr)
@@ -287,8 +336,8 @@ public:
 private:
     Object_Differential_Equation_Representation _differential_equation_representation_object;
     Object_State_Space_Representation _state_space_representation_object;
-    PID _pid_controller;
-    Bang_Bang_Controller _bang_bang_controller;
+    std::shared_ptr<PID> _pid_controller;
+    std::shared_ptr<Bang_Bang_Controller> _bang_bang_controller;
     Heaviside _heaviside;
     Ramp _ramp;
     Rectangle _rect;

--- a/ApplicationCode/include/main_widget.h
+++ b/ApplicationCode/include/main_widget.h
@@ -100,6 +100,16 @@ public:
         return _dependency_handler.get();
     }
 
+public Q_SLOTS:
+
+    void
+    update_pid_parameters_line_edit(std::array<double, 3> pid_parameters)
+    {
+        _controller_parameters_line_edit->setText(
+            QString("[%1, %2, %3]").arg(pid_parameters[0]).arg(pid_parameters[1]).arg(pid_parameters[2]));
+        Q_EMIT _controller_parameters_line_edit->editingFinished();
+    }
+
 Q_SIGNALS:
     void
     plot_control_signal_changed(bool checked);
@@ -117,6 +127,9 @@ private:
     Object_Representation _previous_object_representation {Object_Representation::EQUATION};
     QGridLayout* _input_signal_layout {nullptr};
     QGridLayout* _dynamical_system_layout {nullptr};
+    QComboBox* _control_mode_combobox {nullptr};
+    QComboBox* _controller_type_combobox {nullptr};
+    ClickableLineEdit* _controller_parameters_line_edit {nullptr};
     std::unique_ptr<Dependency_Handler> _dependency_handler {nullptr};
 
     QGroupBox*
@@ -201,36 +214,36 @@ private:
     QGroupBox*
     create_control_loop_group_box()
     {
-        QComboBox* control_mode_combobox = new QComboBox();
-        set_up_combobox(control_mode_combobox, {"Open loop", "Closed loop"});
+        _control_mode_combobox = new QComboBox();
+        set_up_combobox(_control_mode_combobox, {"Open loop", "Closed loop"});
 
-        QComboBox* controller_type_combobox = new QComboBox();
-        set_up_combobox(controller_type_combobox, {"No controller", "Bang-Bang controller", "PID"});
+        _controller_type_combobox = new QComboBox();
+        set_up_combobox(_controller_type_combobox, {"No controller", "Bang-Bang controller", "PID"});
 
-        ClickableLineEdit* controller_parameters_line_edit = new ClickableLineEdit();
+        _controller_parameters_line_edit = new ClickableLineEdit();
         set_up_line_edit(
-            controller_parameters_line_edit, "[1.0, 1.0, 0.0]",
+            _controller_parameters_line_edit, "[1.0, 1.0, 0.0]",
             "<p><i>Enter controller parameters as a vector.</i></p>");
 
-        controller_parameters_line_edit->setEnabled(false);  // No controller as initial controller type.
-        connect(
-            _dependency_handler.get(), &Dependency_Handler::disable_controller_parameters,
-            [controller_parameters_line_edit]() { controller_parameters_line_edit->setEnabled(false); });
-        connect(
-            _dependency_handler.get(), &Dependency_Handler::enable_controller_parameters,
-            [controller_parameters_line_edit]() { controller_parameters_line_edit->setEnabled(true); });
+        _controller_parameters_line_edit->setEnabled(false);  // No controller as initial controller type.
+        connect(_dependency_handler.get(), &Dependency_Handler::disable_controller_parameters, [this]() {
+            _controller_parameters_line_edit->setEnabled(false);
+        });
+        connect(_dependency_handler.get(), &Dependency_Handler::enable_controller_parameters, [this]() {
+            _controller_parameters_line_edit->setEnabled(true);
+        });
 
         QGridLayout* grid_Layout = new QGridLayout();
 
         int row = 0;
         grid_Layout->addWidget(new QLabel("Control mode: "), row, 0);
-        grid_Layout->addWidget(control_mode_combobox, row, 1);
+        grid_Layout->addWidget(_control_mode_combobox, row, 1);
         row++;
         grid_Layout->addWidget(new QLabel("Controller type: "), row, 0);
-        grid_Layout->addWidget(controller_type_combobox, row, 1);
+        grid_Layout->addWidget(_controller_type_combobox, row, 1);
         row++;
         grid_Layout->addWidget(new QLabel("Controller parameters: "), row, 0);
-        grid_Layout->addWidget(controller_parameters_line_edit, row, 1);
+        grid_Layout->addWidget(_controller_parameters_line_edit, row, 1);
 
         QGroupBox* control_loop_group_box = new QGroupBox("Control loop parameters");
         control_loop_group_box->setLayout(grid_Layout);
@@ -258,7 +271,24 @@ private:
     create_application_parameters_group_box()
     {
         QComboBox* operation_combobox = new QComboBox();
-        set_up_combobox(operation_combobox, {"Simulation", "Tuning"});
+        set_up_combobox(operation_combobox, {"Simulation", "PID Tuning"});
+        operation_combobox->setToolTip("Simulate / Tune PID \nTuning available when PID and Closed Loop selected");
+        operation_combobox->setEnabled(false);
+
+        auto const lambda = [this, operation_combobox]() {
+            bool const enable_tuning =
+                (static_cast<Control_Mode>(_control_mode_combobox->currentIndex()) == Control_Mode::CLOSED_LOOP) &&
+                (static_cast<Controller_Type>(_controller_type_combobox->currentIndex()) == Controller_Type::PID);
+            operation_combobox->setEnabled(enable_tuning);
+
+            if(!enable_tuning)
+            {
+                operation_combobox->setCurrentIndex(static_cast<int>(Operation_Type::SIMULATION));
+            }
+        };
+
+        connect(_control_mode_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), lambda);
+        connect(_controller_type_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), lambda);
 
         ClickableLineEdit* simulation_time_line_edit = new ClickableLineEdit();
         set_up_line_edit(simulation_time_line_edit, "10.0", "<p><i>Enter operation time in seconds.</i></p>", true);

--- a/ApplicationCode/include/main_window.h
+++ b/ApplicationCode/include/main_window.h
@@ -22,6 +22,9 @@ class Main_Window : public QMainWindow
 public:
     Main_Window() : _main_widget(new Main_Widget(this)), _simulator(this)
     {
+        connect(
+            &_simulator, &Simulator::update_pid_parameters_line_edit_after_tuning, _main_widget,
+            &Main_Widget::update_pid_parameters_line_edit);
         this->setWindowTitle(window_title);
         this->setCentralWidget(_main_widget);
 

--- a/ApplicationCode/include/simulator.h
+++ b/ApplicationCode/include/simulator.h
@@ -5,6 +5,7 @@
 
 #include <QtWidgets/QApplication>
 #include "control.h"
+#include "enums.h"
 #include "input_parameters_container.h"
 #include "plotter.h"
 
@@ -32,16 +33,14 @@ public:
             {input_parameters.get_A_matrix(), input_parameters.get_B_vector(), input_parameters.get_C_vector(),
              input_parameters.get_D()});
         _control.set_control_mode(input_parameters.get_control_mode());
-
-        // Prior to setting the controller - to update it properly.
+        _control.set_controller(
+            simulation_time_step, input_parameters.get_controller_type(), input_parameters.get_controller_parameters());
         if(input_parameters.get_controller_type() == Controller_Type::PID)
         {
             _control.enable_pid_derivative_filtering(input_parameters.get_enable_pid_derivative_filtering());
             _control.set_pid_derivative_filtering_coefficient(
                 input_parameters.get_pid_derivative_filtering_coefficient());
         }
-        _control.set_controller(
-            simulation_time_step, input_parameters.get_controller_type(), input_parameters.get_controller_parameters());
         _control.set_signal(
             simulation_time_step, input_parameters.get_input_signal(),
             input_parameters.get_input_signal_basic_parameters(),
@@ -73,6 +72,11 @@ public:
             }
             QApplication::processEvents();
         }
+
+        if(_control.get_operation_type() == Operation_Type::TUNING)
+        {
+            Q_EMIT update_pid_parameters_line_edit_after_tuning(_control.get_pid_parameters());
+        }
     }
 
     void
@@ -80,6 +84,10 @@ public:
     {
         _break_simulation = true;
     }
+
+Q_SIGNALS:
+    void
+    update_pid_parameters_line_edit_after_tuning(std::array<double, 3> pid_parameters);
 
 private:
     void

--- a/LogicCode/include/pid.h
+++ b/LogicCode/include/pid.h
@@ -50,6 +50,12 @@ public:
         return {get_error(), _error_int.get_value(), _error_der.get_value()};
     }
 
+    std::array<double, 3>
+    get_parameters() const
+    {
+        return {_parameters.kp, _parameters.ki, _parameters.kd};
+    }
+
     void
     set_parameters(std::vector<double> const& parameters) override
     {

--- a/LogicCode/include/pid_tuner.h
+++ b/LogicCode/include/pid_tuner.h
@@ -36,6 +36,12 @@ public:
     }
 
     void
+    set_initial_pid_parameters(std::array<double, 3> pid_parameters)
+    {
+        _regression.set_initial_coefficients(pid_parameters);
+    }
+
+    void
     reset()
     {
         _control_system.reset();

--- a/LogicCode/include/recursive_linear_regression.h
+++ b/LogicCode/include/recursive_linear_regression.h
@@ -14,7 +14,7 @@ public:
     Recursive_Linear_Regression(double lambda = 0.99)
     {
         _lambda = (lambda > 0.0 && lambda <= 1.0) ? lambda : 1.0;
-        create_diagonal_matrix<MatrixT>(_P, 1.0);
+        create_diagonal_matrix(_P, 1.0);
     }
 
     void
@@ -23,32 +23,32 @@ public:
         double const e = 10e-6;
 
         VectorT K {};
-        matrix_vector_multiplication_vector_product<MatrixT, VectorT>(K, _P, x);
+        matrix_vector_multiplication_vector_product(K, _P, x);
         VectorT P_x {};
-        matrix_vector_multiplication_vector_product<MatrixT, VectorT>(P_x, _P, x);
-        double const scalar = vectors_multiplication_scalar_product<VectorT>(x, P_x);
+        matrix_vector_multiplication_vector_product(P_x, _P, x);
+        double const scalar = vectors_multiplication_scalar_product(x, P_x);
 
         double const denominator = std::max(scalar + _lambda, e);
-        scale_vector<VectorT>(K, 1.0 / denominator);
+        scale_vector(K, 1.0 / denominator);
 
         VectorT K_epsilon_scaled = K;
-        scale_vector<VectorT>(K_epsilon_scaled, epsilon);
+        scale_vector(K_epsilon_scaled, epsilon);
 
         VectorT new_coefficients {};
-        add_vectors<VectorT>(new_coefficients, _coefficients, K_epsilon_scaled);
+        add_vectors(new_coefficients, _coefficients, K_epsilon_scaled);
         _coefficients = new_coefficients;
 
         VectorT xT_P {};
-        vector_matrix_multiplication_vector_product<VectorT, MatrixT>(xT_P, x, _P);
+        vector_matrix_multiplication_vector_product(xT_P, x, _P);
 
         MatrixT mul_product {};
-        vectors_multiplication_matrix_product<MatrixT, VectorT>(mul_product, K, xT_P);
+        vectors_multiplication_matrix_product(mul_product, K, xT_P);
 
         MatrixT new_P {};
-        subtract_matrices<MatrixT>(new_P, _P, mul_product);
+        subtract_matrices(new_P, _P, mul_product);
         _P = new_P;
 
-        scale_matrix<MatrixT>(_P, _lambda);
+        scale_matrix(_P, _lambda);
     }
 
     VectorT const&
@@ -58,11 +58,16 @@ public:
     }
 
     void
+    set_initial_coefficients(VectorT const& coefficients)
+    {
+        _coefficients = coefficients;
+    }
+
+    void
     reset()
     {
         _P = {};
-        create_diagonal_matrix<MatrixT>(_P, 1.0);
-        _coefficients = {};
+        create_diagonal_matrix(_P, 1.0);
     }
 
 private:


### PR DESCRIPTION
- introduced experimental PID tuning using RLS,
- controllers swapped for std::shared_ptr instead of raw types, so that when switching with _selected_controller, not copies but the originals are referenced,
- signals and slots introduced to allow for updating PID parameters with the tuned ones.
- tuner can also start with the initial PID params.