### PR TITLE
Work/no signal as input

### DIFF
--- a/ApplicationCode/include/control.h
+++ b/ApplicationCode/include/control.h
@@ -35,9 +35,10 @@ public:
           _rect(std::make_shared<Rectangle>(TIME_STEP)),
           _sine_wave(std::make_shared<Sine_Wave>(TIME_STEP)),
           _pulse_wave(std::make_shared<Pulse_Wave>(TIME_STEP)),
+          _no_signal(std::make_shared<No_Signal>(TIME_STEP)),
           _selected_object(nullptr),
           _selected_controller(nullptr),
-          _selected_input_signal(_heaviside),
+          _selected_input_signal(_no_signal),
           _regression(),
           _system(_selected_object, Control_System::Control_Mode::OPEN_LOOP),
           _tuner(_system, _regression),
@@ -132,6 +133,11 @@ public:
     {
         switch(input_signal)
         {
+            case Input_Signal::NO_SIGNAL:
+            {
+                _selected_input_signal = _no_signal;
+                break;
+            }
             case Input_Signal::HEAVISIDE:
             {
                 _selected_input_signal = _heaviside;
@@ -360,6 +366,7 @@ private:
     std::shared_ptr<Rectangle> _rect;
     std::shared_ptr<Sine_Wave> _sine_wave;
     std::shared_ptr<Pulse_Wave> _pulse_wave;
+    std::shared_ptr<No_Signal> _no_signal;
 
     std::shared_ptr<Object_Representation_Base> _selected_object;
     std::shared_ptr<Controller_Base> _selected_controller;

--- a/ApplicationCode/include/dependency_handler.h
+++ b/ApplicationCode/include/dependency_handler.h
@@ -39,6 +39,9 @@ public:
         connect(
             _inputs_parser.get(), &Inputs_Parser::controller_type_changed, this,
             &Dependency_Handler::controller_type_changed);
+        connect(
+            _inputs_parser.get(), &Inputs_Parser::input_signal_changed, this,
+            &Dependency_Handler::input_signal_changed);
     }
 
     Input_Parameters_Container const&
@@ -151,4 +154,7 @@ Q_SIGNALS:
 
     void
     controller_type_changed(std::vector<double> const& controller_parameters);
+
+    void
+    input_signal_changed(Signal_Base::Signal_Basic_Parameters const& signal_basic_parameters);
 };

--- a/ApplicationCode/include/enums.h
+++ b/ApplicationCode/include/enums.h
@@ -59,6 +59,7 @@ enum class Controller_Type : std::uint8_t
 
 enum class Input_Signal : std::uint8_t
 {
+    NO_SIGNAL,
     HEAVISIDE,
     RAMP,
     RECTANGLE,

--- a/ApplicationCode/include/input_parameters_container.h
+++ b/ApplicationCode/include/input_parameters_container.h
@@ -3,6 +3,9 @@
 
 #pragma once
 #include <cstdint>
+#include <map>
+#include <string>
+#include <unordered_map>
 #include <vector>
 #include "base_classes/signal_base.h"
 #include "enums.h"
@@ -19,8 +22,7 @@ class Input_Parameters_Container
         std::vector<double> B_vector              = {0.0, 1.0};
         std::vector<double> C_vector              = {1.0, 0.0};
         double D {0.0};
-        double start_time {0.0};
-        double scaler {1.0};
+        std::unordered_map<Input_Signal, std::unordered_map<std::string, double>> input_signal_basic_parameters_map;
         double on_time {5.0};
         double omega {1.0};
         double offset {0.0};
@@ -30,6 +32,16 @@ class Input_Parameters_Container
         double measurement_noise_std {0.001};
         double pid_derivative_filtering_coefficient {0.5};
         double RLS_forgetting_factor {0.99};
+
+        LineEdit_Inputs()
+        {
+            for(int i = static_cast<int>(Input_Signal::NO_SIGNAL); i <= static_cast<int>(Input_Signal::PULSE_WAVE); ++i)
+            {
+                Input_Signal const signal_type                               = static_cast<Input_Signal>(i);
+                input_signal_basic_parameters_map[signal_type]["start_time"] = 0.0;
+                input_signal_basic_parameters_map[signal_type]["scaler"]     = 1.0;
+            }
+        }
     };
 
     struct ComboBoxes_Inputs
@@ -138,13 +150,13 @@ public:
     void
     set_start_time(double start_time)
     {
-        _line_edit_inputs.start_time = start_time;
+        _line_edit_inputs.input_signal_basic_parameters_map[get_input_signal()]["start_time"] = start_time;
     }
 
     void
     set_scaler(double scaler)
     {
-        _line_edit_inputs.scaler = scaler;
+        _line_edit_inputs.input_signal_basic_parameters_map[get_input_signal()]["scaler"] = scaler;
     }
 
     void
@@ -371,7 +383,9 @@ public:
     Signal_Base::Signal_Basic_Parameters
     get_input_signal_basic_parameters() const
     {
-        return {_line_edit_inputs.start_time, _line_edit_inputs.scaler};
+        return {
+            _line_edit_inputs.input_signal_basic_parameters_map.at(get_input_signal()).at("start_time"),
+            _line_edit_inputs.input_signal_basic_parameters_map.at(get_input_signal()).at("scaler")};
     }
 
     std::array<double, 5>

--- a/ApplicationCode/include/input_parameters_container.h
+++ b/ApplicationCode/include/input_parameters_container.h
@@ -37,7 +37,7 @@ class Input_Parameters_Container
         Object_Representation object_representation = Object_Representation::EQUATION;
         Control_Mode control_mode                   = Control_Mode::OPEN_LOOP;
         Controller_Type controller_type             = Controller_Type::NONE;
-        Input_Signal input_signal                   = Input_Signal::HEAVISIDE;
+        Input_Signal input_signal                   = Input_Signal::NO_SIGNAL;
         Operation_Type operation_type               = Operation_Type::SIMULATION;
         double simulation_time_step {0.01};
     };

--- a/ApplicationCode/include/inputs_parser.h
+++ b/ApplicationCode/include/inputs_parser.h
@@ -171,6 +171,7 @@ public:
             case ComboBox_ID::INPUT_SIGNAL:
             {
                 _inputs.set_input_signal(static_cast<Input_Signal>(current_index));
+                Q_EMIT input_signal_changed(_inputs.get_input_signal_basic_parameters());
                 break;
             }
             case ComboBox_ID::OPERATION_TYPE:
@@ -377,6 +378,9 @@ Q_SIGNALS:
 
     void
     controller_type_changed(std::vector<double> const& controller_parameters);
+
+    void
+    input_signal_changed(Signal_Base::Signal_Basic_Parameters const& signal_basic_parameters);
 
 private:
     Input_Parameters_Container _inputs {};

--- a/ApplicationCode/include/main_widget.h
+++ b/ApplicationCode/include/main_widget.h
@@ -145,7 +145,6 @@ Q_SIGNALS:
 private:
     int combobox_id  = 0;
     int line_edit_id = 0;
-    Input_Signal _previous_input_signal_type {Input_Signal::HEAVISIDE};
     Object_Representation _previous_object_representation {Object_Representation::EQUATION};
     QGridLayout* _input_signal_layout {nullptr};
     QGridLayout* _dynamical_system_layout {nullptr};
@@ -277,7 +276,8 @@ private:
     create_input_signal_group_box()
     {
         QComboBox* input_signal_combobox = new QComboBox();
-        set_up_combobox(input_signal_combobox, {"Heaviside", "Ramp", "Rectangle", "Sine wave", "Pulse wave"});
+        set_up_combobox(
+            input_signal_combobox, {"No Signal", "Heaviside", "Ramp", "Rectangle", "Sine wave", "Pulse wave"});
         connect(
             input_signal_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &update_input_signal_layout);
@@ -337,6 +337,12 @@ private:
     QGridLayout*
     input_signal_group_box_layout(QComboBox* input_signal_combobox)
     {
+        QLabel* start_time_label = new QLabel("Start time [s]: ");
+        start_time_label->hide();
+
+        QLabel* scaler_label = new QLabel("Scaler: ");
+        scaler_label->hide();
+
         QLabel* on_time_label = new QLabel("On time [s]: ");
         on_time_label->hide();
 
@@ -356,9 +362,11 @@ private:
 
         ClickableLineEdit* start_time_line_edit = new ClickableLineEdit();
         set_up_line_edit(start_time_line_edit, "0.0", "<p><i>Set up start time in seconds.</i></p>");
+        start_time_line_edit->hide();
 
         ClickableLineEdit* scaler_line_edit = new ClickableLineEdit();
         set_up_line_edit(scaler_line_edit, "1.0", "<p><i>Set up scaler parameter.</i></p>");
+        scaler_line_edit->hide();
 
         ClickableLineEdit* on_time_line_edit = new ClickableLineEdit();
         set_up_line_edit(on_time_line_edit, "5.0", "<p><i>Set up on time in seconds.</i></p>");
@@ -382,18 +390,16 @@ private:
 
         QGridLayout* grid_Layout = new QGridLayout();
 
-        // Default widgets (shared among all the input signals) are not hidden.
         int row = 0;
         grid_Layout->addWidget(new QLabel("Input signal type: "), row, 0);
         grid_Layout->addWidget(input_signal_combobox, row, 1);
         row++;
-        grid_Layout->addWidget(new QLabel("Start time [s]: "), row, 0);
+        grid_Layout->addWidget(start_time_label, row, 0);
         grid_Layout->addWidget(start_time_line_edit, row, 1);
         row++;
-        grid_Layout->addWidget(new QLabel("Scaler: "), row, 0);
+        grid_Layout->addWidget(scaler_label, row, 0);
         grid_Layout->addWidget(scaler_line_edit, row, 1);
         row++;
-
         grid_Layout->addWidget(on_time_label, row, 0);
         grid_Layout->addWidget(on_time_line_edit, row, 1);
         row++;
@@ -435,39 +441,11 @@ private:
             &Dependency_Handler::comboboxes_callback);
     }
 
-    int
-    get_valid_grid_layout_row(Input_Signal signal_type) const
-    {
-        int valid_row = 0;
-        switch(signal_type)
-        {
-            case Input_Signal::RECTANGLE:
-            {
-                valid_row = static_cast<int>(signal_type) + 1;
-                break;
-            }
-            case Input_Signal::SINE_WAVE:
-            {
-                valid_row = static_cast<int>(signal_type) + 1;
-                break;
-            }
-            case Input_Signal::PULSE_WAVE:
-            {
-                valid_row = static_cast<int>(signal_type) + 2;
-                break;
-            }
-            default:
-            {
-                break;
-            }
-        }
-        return valid_row;
-    }
-
     void
     hide_show_grid_layout_widgets(QGridLayout* grid_layout, int beginning_row, int rows_to_hide_show, bool hide)
     {
-        for(int row = beginning_row; (row < grid_layout->rowCount() && row < beginning_row + rows_to_hide_show); row++)
+        for(int row = beginning_row; (row < grid_layout->rowCount()) && (row < beginning_row + rows_to_hide_show);
+            row++)
         {
             for(int column = 0; column < grid_layout->columnCount(); column++)
             {
@@ -502,55 +480,37 @@ private Q_SLOTS:
             return;
         }
 
-        int const previous_signal_type_row = get_valid_grid_layout_row(_previous_input_signal_type);
-        switch(_previous_input_signal_type)
+        static constexpr int starting_row = 1;
+        hide_show_grid_layout_widgets(_input_signal_layout, starting_row, _input_signal_layout->rowCount(), true);
+
+        static constexpr int number_of_basic_signal_parameters = 2;
+        static constexpr int rect_starting_row                 = 3;
+        static constexpr int sine_wave_starting_row            = 4;
+        static constexpr int pulse_wave_starting_row           = 6;
+        static constexpr int rect_rows                         = 1;
+        static constexpr int sine_wave_rows                    = 2;
+        static constexpr int pulse_wave_rows                   = 2;
+
+        Input_Signal const signal_type = static_cast<Input_Signal>(combobox->currentIndex());
+        if(signal_type != Input_Signal::NO_SIGNAL)
         {
-            case Input_Signal::RECTANGLE:
-            {
-                hide_show_grid_layout_widgets(_input_signal_layout, previous_signal_type_row, 1, true);
-                break;
-            }
-            case Input_Signal::SINE_WAVE:
-            {
-                hide_show_grid_layout_widgets(_input_signal_layout, previous_signal_type_row, 2, true);
-                break;
-            }
-            case Input_Signal::PULSE_WAVE:
-            {
-                hide_show_grid_layout_widgets(_input_signal_layout, previous_signal_type_row, 2, true);
-                break;
-            }
-            default:
-            {
-                break;  // Don't hide anything for HEAVISIDE/RAMP input signal as it's just basic layout.
-            }
+            hide_show_grid_layout_widgets(_input_signal_layout, starting_row, number_of_basic_signal_parameters, false);
         }
 
-        Input_Signal const signal_type    = static_cast<Input_Signal>(combobox->currentIndex());
-        int const current_signal_type_row = get_valid_grid_layout_row(signal_type);
         switch(signal_type)
         {
             case Input_Signal::RECTANGLE:
-            {
-                hide_show_grid_layout_widgets(_input_signal_layout, current_signal_type_row, 1, false);
+                hide_show_grid_layout_widgets(_input_signal_layout, rect_starting_row, rect_rows, false);
                 break;
-            }
             case Input_Signal::SINE_WAVE:
-            {
-                hide_show_grid_layout_widgets(_input_signal_layout, current_signal_type_row, 2, false);
+                hide_show_grid_layout_widgets(_input_signal_layout, sine_wave_starting_row, sine_wave_rows, false);
                 break;
-            }
             case Input_Signal::PULSE_WAVE:
-            {
-                hide_show_grid_layout_widgets(_input_signal_layout, current_signal_type_row, 2, false);
+                hide_show_grid_layout_widgets(_input_signal_layout, pulse_wave_starting_row, pulse_wave_rows, false);
                 break;
-            }
             default:
-            {
-                break;  // Don't show anything for HEAVISIDE/RAMP input signal as it's just basic layout.
-            }
+                break;
         }
-        _previous_input_signal_type = signal_type;
     }
 
     void
@@ -562,26 +522,26 @@ private Q_SLOTS:
             return;
         }
 
-        static int const EQUATION_BEGINNING_ROW    = 2;
-        static int const EQUATION_LAYOUT_ROWS      = 1;
-        static int const STATE_SPACE_BEGINNING_ROW = 3;
-        static int const STATE_SPACE_LAYOUT_ROWS   = 4;
+        static constexpr int equation_beginning_row    = 2;
+        static constexpr int equation_layout_rows      = 1;
+        static constexpr int state_space_beginning_row = 3;
+        static constexpr int state_space_layout_rows   = 4;
         switch(_previous_object_representation)
         {
             case Object_Representation::EQUATION:
             {
                 hide_show_grid_layout_widgets(
-                    _dynamical_system_layout, EQUATION_BEGINNING_ROW, EQUATION_LAYOUT_ROWS, true);
+                    _dynamical_system_layout, equation_beginning_row, equation_layout_rows, true);
                 hide_show_grid_layout_widgets(
-                    _dynamical_system_layout, STATE_SPACE_BEGINNING_ROW, STATE_SPACE_LAYOUT_ROWS, false);
+                    _dynamical_system_layout, state_space_beginning_row, state_space_layout_rows, false);
                 break;
             }
             case Object_Representation::STATE_SPACE:
             {
                 hide_show_grid_layout_widgets(
-                    _dynamical_system_layout, STATE_SPACE_BEGINNING_ROW, STATE_SPACE_LAYOUT_ROWS, true);
+                    _dynamical_system_layout, state_space_beginning_row, state_space_layout_rows, true);
                 hide_show_grid_layout_widgets(
-                    _dynamical_system_layout, EQUATION_BEGINNING_ROW, EQUATION_LAYOUT_ROWS, false);
+                    _dynamical_system_layout, equation_beginning_row, equation_layout_rows, false);
                 break;
             }
             default:

--- a/ApplicationCode/include/main_widget.h
+++ b/ApplicationCode/include/main_widget.h
@@ -55,6 +55,9 @@ public:
         connect(
             _dependency_handler.get(), &Dependency_Handler::controller_type_changed, this,
             &Main_Widget::controller_type_changed);
+        connect(
+            _dependency_handler.get(), &Dependency_Handler::input_signal_changed, this,
+            &Main_Widget::input_signal_changed);
 
         QGroupBox* dynamical_system_group_box       = create_dynamical_system_group_box();
         QGroupBox* control_loop_group_box           = create_control_loop_group_box();
@@ -151,6 +154,8 @@ private:
     QComboBox* _control_mode_combobox {nullptr};
     QComboBox* _controller_type_combobox {nullptr};
     ClickableLineEdit* _controller_parameters_line_edit {nullptr};
+    ClickableLineEdit* _start_time_line_edit {nullptr};
+    ClickableLineEdit* _scaler_line_edit {nullptr};
     std::unique_ptr<Dependency_Handler> _dependency_handler {nullptr};
 
     QGroupBox*
@@ -360,13 +365,13 @@ private:
 
         line_edit_id = static_cast<int>(LineEdit_ID::START_TIME_LINE_EDIT);
 
-        ClickableLineEdit* start_time_line_edit = new ClickableLineEdit();
-        set_up_line_edit(start_time_line_edit, "0.0", "<p><i>Set up start time in seconds.</i></p>");
-        start_time_line_edit->hide();
+        _start_time_line_edit = new ClickableLineEdit();
+        set_up_line_edit(_start_time_line_edit, "0.0", "<p><i>Set up start time in seconds.</i></p>");
+        _start_time_line_edit->hide();
 
-        ClickableLineEdit* scaler_line_edit = new ClickableLineEdit();
-        set_up_line_edit(scaler_line_edit, "1.0", "<p><i>Set up scaler parameter.</i></p>");
-        scaler_line_edit->hide();
+        _scaler_line_edit = new ClickableLineEdit();
+        set_up_line_edit(_scaler_line_edit, "1.0", "<p><i>Set up scaler parameter.</i></p>");
+        _scaler_line_edit->hide();
 
         ClickableLineEdit* on_time_line_edit = new ClickableLineEdit();
         set_up_line_edit(on_time_line_edit, "5.0", "<p><i>Set up on time in seconds.</i></p>");
@@ -395,10 +400,10 @@ private:
         grid_Layout->addWidget(input_signal_combobox, row, 1);
         row++;
         grid_Layout->addWidget(start_time_label, row, 0);
-        grid_Layout->addWidget(start_time_line_edit, row, 1);
+        grid_Layout->addWidget(_start_time_line_edit, row, 1);
         row++;
         grid_Layout->addWidget(scaler_label, row, 0);
-        grid_Layout->addWidget(scaler_line_edit, row, 1);
+        grid_Layout->addWidget(_scaler_line_edit, row, 1);
         row++;
         grid_Layout->addWidget(on_time_label, row, 0);
         grid_Layout->addWidget(on_time_line_edit, row, 1);
@@ -557,6 +562,15 @@ private Q_SLOTS:
     controller_type_changed(std::vector<double> const& controller_parameters)
     {
         set_controller_parameters_line_edit_text(controller_parameters);
+    }
+
+    void
+    input_signal_changed(Signal_Base::Signal_Basic_Parameters const& signal_basic_parameters)
+    {
+        _start_time_line_edit->setText(QString::number(signal_basic_parameters.start_time, 'f', 1));
+        _scaler_line_edit->setText(QString::number(signal_basic_parameters.scaler, 'f', 1));
+        Q_EMIT _start_time_line_edit->editingFinished();
+        Q_EMIT _scaler_line_edit->editingFinished();
     }
 
     void

--- a/LogicCode/include/signals.h
+++ b/LogicCode/include/signals.h
@@ -6,6 +6,26 @@
 #include <cstdint>
 #include "base_classes/signal_base.h"
 
+class No_Signal : public Signal_Base
+{
+public:
+    No_Signal(double time_step, Signal_Basic_Parameters const& parameters) : Signal_Base(time_step, parameters) {}
+
+    No_Signal(double time_step) : No_Signal(time_step, {}) {}
+
+    void
+    update() override
+    {
+        update_timer();
+    }
+
+    void
+    reset() override
+    {
+        reset_timer();
+    }
+};
+
 // NOTE: Heaviside function - a * 1(t - t0).
 class Heaviside : public Signal_Base
 {


### PR DESCRIPTION
- added the "No_Signal" option to actually have the zero input possible - useful for testing only the object's response to initial conditions,
- additionally, basic input signal parameters have been differentiated for each type, so that they wouldn't override one another.